### PR TITLE
fix/DEV-161 Ensures Social actions are rendered with other elements at the same time.

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -25,11 +25,10 @@ Fliplet.Widget.instance({
       });
 
       /**
-       * Finds and returns the parent widget and its entry data for a specified widget type
-       * @param {('RecordContainer'|'ListRepeater'|'DynamicContainer')} type - The type of parent widget to search for
-       * @returns {Promise<[Object|null, Object|null]>} A tuple containing:
-       *   - The parent widget configuration if found, null otherwise
-       *   - The parent widget instance if found, null otherwise
+       * Finds and returns the parent widget and its entry data for a specified widget type.
+       * @param {string} type - The type of parent widget to search for
+       * @param {string} packageName - The widget package name to match
+       * @returns {Promise<Array>} Promise resolving to [parentConfig|null, parentInstance|null]
        * @async
        * @private
        */
@@ -92,62 +91,7 @@ Fliplet.Widget.instance({
 
       socialAction.dataSourceLfdId = dynamicContainer.dataSourceId;
 
-      const accessRulesObj = {
-        accessRulesBookmarks: [
-          { 'type': ['insert'], 'allow': 'all', 'enabled': true,
-            'require': [
-              { 'Type': { 'equals': 'Bookmark' } }
-            ]
-          },
-          { 'type': ['delete'], 'allow': 'loggedIn', 'enabled': true,
-            'require': [
-              { 'Type': { 'equals': 'Bookmark' } },
-              { 'Email': { 'equals': '{{user.[Email]}}' } }
-            ]
-          },
-          { 'type': ['delete'], 'allow': 'all', 'enabled': true,
-            'require': [
-              { 'Type': { 'equals': 'Bookmark' } },
-              { 'Device Uuid': { 'equals': '{{session.uuid}}' } }
-            ]
-          },
-          { 'type': ['select'], 'allow': 'all', 'enabled': true, 'require': [
-            { 'Type': { 'equals': 'Bookmark' } },
-            { 'Email': { 'equals': '{{user.[Email]}}' } }
-          ]
-          },
-          // TODO remove this condition when we agree on the security rules
-          { 'type': ['select'], 'allow': 'all', 'enabled': true },
-          { 'type': ['select'], 'allow': 'all', 'enabled': true,
-            'require': [
-              { 'Type': { 'equals': 'Bookmark' } },
-              { 'Device Uuid': { 'equals': '{{session.uuid}}' } }
-            ]
-          }
-        ],
-        accessRulesLikes: [
-          { 'type': ['insert'], 'allow': 'loggedIn', 'enabled': true,
-            'require': [
-              { 'Type': { 'equals': 'Like' } }
-            ]
-          },
-          { 'type': ['delete'], 'allow': 'loggedIn', 'enabled': true,
-            'require': [
-              { 'Type': { 'equals': 'Like' } },
-              { 'Email': { 'equals': '{{user.[Email]}}' } }
-            ]
-          },
-          { 'type': ['select'], 'allow': 'loggedIn', 'enabled': true,
-            'require': [
-              { 'Type': { 'equals': 'Like' } }
-            ]
-          }
-        ]
-      };
-
-      const accessRules = [...accessRulesObj.accessRulesBookmarks, ...accessRulesObj.accessRulesLikes];
       const deviceUuid = Fliplet.Profile.getDeviceUuid().uuid;
-      const globalSocialActionsDataSource = 'Global Data interactive icon';
 
       socialAction.fields = _.assign(
         {
@@ -157,10 +101,6 @@ Fliplet.Widget.instance({
       );
 
       const selectedOption = socialAction.fields.typeOfSocialFeature;
-      const columnsForSocialDataSource = [
-        'Email', 'Data Source Id', 'Data Source Entry Id', 'Datetime', 'Type', 'Device Uuid'
-      ];
-      const appId = Fliplet.Env.get('appId');
 
       // Ensure the correct icon is shown immediately to avoid late appearance
       const $initialEl = $(socialAction.$el);
@@ -203,24 +143,38 @@ Fliplet.Widget.instance({
       // TODO - it is not optimized at all to call get and create every time
       // TODO - Eng should create a solution to create this DS on every app creation?
       // TODO - It might be better to be hidden from the user
-      function manageSocialActionDataSource(dataSourceId, entryId) {
-        return Fliplet.DataSources.get({
-          attributes: ['id', 'name'],
-          where: { appId }
-        })
-          .then(function(dataSources) {
-            const dsExist = dataSources.find(el => el.name === globalSocialActionsDataSource);
+      /**
+       * Polls until the provided condition returns a truthy value or a timeout elapses
+       * @param {Function} conditionFn - Function returning a truthy value when ready
+       * @param {Object} options - Configuration options
+       * @param {number} options.intervalMs - Interval between checks in milliseconds
+       * @param {number} options.timeoutMs - Maximum time to wait in milliseconds
+       * @returns {Promise<*>} Resolves with the condition result or null on timeout
+       * @private
+       */
+      function waitFor(conditionFn, options) {
+        const opts = options || {};
+        const intervalMs = typeof opts.intervalMs === 'number' ? opts.intervalMs : 100;
+        const timeoutMs = typeof opts.timeoutMs === 'number' ? opts.timeoutMs : 5000;
 
-            if (!dsExist) {
-              return Fliplet.DataSources.create({
-                name: globalSocialActionsDataSource,
-                appId,
-                columns: columnsForSocialDataSource,
-                accessRules
-              }).then(function(newDataSource) {
-                setAttributes(dataSourceId, newDataSource.id, entryId);
-                setActionClickEvent();
-              });
+        return new Promise(function(resolve) {
+          const start = Date.now();
+
+          function check() {
+            let result;
+
+            try {
+              result = conditionFn();
+            } catch (e) {
+              // Ignore errors during evaluation and keep polling
+            }
+
+            if (result) {
+              return resolve(result);
+            }
+
+            if (Date.now() - start >= timeoutMs) {
+              return resolve(null);
             }
 
             setTimeout(check, intervalMs);
@@ -272,7 +226,7 @@ Fliplet.Widget.instance({
         }
       }
 
-      function setActionClickEvent() {
+      function setActionClickEvent(cachedSessionData) {
         $(socialAction.$el).find('.social-actions').off('click').on('click', function() {
           const $thisClick = $(this);
           const originalDataSource = $thisClick.data('original-datasource-id');
@@ -297,8 +251,7 @@ Fliplet.Widget.instance({
           $thisClick.data('busy', true);
 
 
-          return Fliplet.User.getCachedSession().then(function(session) {
-            let user = '';
+          let user = '';
 
           if (cachedSessionData && cachedSessionData.entries) {
             user = handleSession(cachedSessionData);
@@ -339,51 +292,20 @@ Fliplet.Widget.instance({
                     });
                 }
 
-            return Fliplet.DataSources.connect(globalDataSourceId)
-              .then(function(connection) {
-                let where = {
+                return connection.insert({
+                  'Email': user ? user.Email : '',
+                  'Device Uuid': deviceUuid,
                   'Data Source Id': originalDataSource,
                   'Data Source Entry Id': normalizedEntryId,
                   'Datetime': new Date().toISOString(),
                   'Type': $thisClick.find('.bookmark:visible').length !== 0 ? 'Bookmark' : 'Like'
-                };
-
-                if (user) {
-                  where.Email = user.Email;
-                } else {
-                  where['Device Uuid'] = deviceUuid;
-                }
-
-                return connection.findOne({
-                  where
-                }).then(function(record) {
-                  if (record) {
-                    return connection.removeById(record.id)
-                      .then(function onRemove() {
-                        if ($thisClick.find('.bookmark:visible').length !== 0) {
-                          $thisClick.find('.bookmark').toggleClass('fa-bookmark fa-bookmark-o');
-                        } else {
-                          $thisClick.find('.like').toggleClass('fa-heart fa-heart-o');
-                          $thisClick.find('.like-count').html(Number($thisClick.find('.like-count').text()) - 1);
-                        }
-                      });
+                }).then(function() {
+                  if ($thisClick.find('.bookmark:visible').length !== 0) {
+                    $thisClick.find('.bookmark').toggleClass('fa-bookmark fa-bookmark-o');
+                  } else {
+                    $thisClick.find('.like').toggleClass('fa-heart fa-heart-o');
+                    $thisClick.find('.like-count').html(Number($thisClick.find('.like-count').text()) + 1);
                   }
-
-                  return connection.insert({
-                    'Email': user ? user.Email : '',
-                    'Device Uuid': deviceUuid,
-                    'Data Source Id': originalDataSource,
-                    'Data Source Entry Id': dataSourceEntryId,
-                    'Datetime': new Date().toISOString(),
-                    'Type': $thisClick.find('.bookmark:visible').length !== 0 ? 'Bookmark' : 'Like'
-                  }).then(function() {
-                    if ($thisClick.find('.bookmark:visible').length !== 0) {
-                      $thisClick.find('.bookmark').toggleClass('fa-bookmark fa-bookmark-o');
-                    } else {
-                      $thisClick.find('.like').toggleClass('fa-heart fa-heart-o');
-                      $thisClick.find('.like-count').html(Number($thisClick.find('.like-count').text()) + 1);
-                    }
-                  });
                 });
               });
             })
@@ -397,11 +319,18 @@ Fliplet.Widget.instance({
         });
       }
 
-      function setAttributes(dataSourceId, globalDataSourceId, entryId) {
+      function setAttributes(dataSourceId, globalSocialActionsDSData, entryId, globalSocialActionsDSId, cachedSessionData) {
         const $el = $(socialAction.$el);
 
-        return Fliplet.User.getCachedSession().then(function(session) {
-          let user = '';
+        let user = '';
+
+        if (cachedSessionData && cachedSessionData.entries) {
+          user = handleSession(cachedSessionData);
+        }
+
+        const filteredGlobalSocialActionsDSData = globalSocialActionsDSData && globalSocialActionsDSData.filter((row) => {
+          const rowData = row.data || {};
+          const userEmail = user ? user.Email : '';
 
           return rowData['Data Source Id'] === dataSourceId &&
             String(rowData['Data Source Entry Id']) === String(entryId) &&
@@ -409,67 +338,42 @@ Fliplet.Widget.instance({
             (rowData['Email'] === userEmail || rowData['Device Uuid'] === deviceUuid);
         });
 
-          return Fliplet.DataSources.connect(globalDataSourceId)
-            .then(function(connection) {
-              let where = {
-                'Data Source Id': dataSourceId,
-                'Data Source Entry Id': entryId,
-                'Type': selectedOption
-              };
+        if (selectedOption === 'Bookmark') {
+          $el.find('.like').hide();
+          $el.find('.bookmark').show();
 
-              if (user) {
-                where.Email = user.Email;
-              } else {
-                where['Device Uuid'] = deviceUuid;
-              }
+          if (filteredGlobalSocialActionsDSData && filteredGlobalSocialActionsDSData.length) {
+            $el.find('.bookmark')
+              .addClass('fa-bookmark')
+              .removeClass('fa-bookmark-o');
+          }
 
-              if (selectedOption === 'Bookmark') {
-                return connection.findOne({
-                  where
-                }).then(function(record) {
-                  $el.find('.like').hide();
-                  $el.find('.bookmark').show();
+          $el.find('.social-actions')
+            .attr('data-original-datasource-id', dataSourceId);
+          $el.find('.social-actions')
+            .attr('data-global-datasource-id', globalSocialActionsDSId);
+          $el.find('.social-actions')
+            .attr('data-entry-id', entryId);
+        } else if (selectedOption === 'Like') {
+          $el.find('.like').show();
+          $el.find('.like-count').show();
+          $el.find('.like-container').css('display', 'flex');
 
-                  if (record) {
-                    $el.find('.bookmark')
-                      .addClass('fa-bookmark')
-                      .removeClass('fa-bookmark-o');
-                  }
+          if (filteredGlobalSocialActionsDSData && filteredGlobalSocialActionsDSData.find(el =>
+            el.data.Email === (user ? user.Email : '') || el.data['Device Uuid'] === deviceUuid)) {
+            $el.find('.like')
+              .addClass('fa-heart')
+              .removeClass('fa-heart-o');
+          }
 
-                  $el.find('.social-actions')
-                    .attr('data-original-datasource-id', dataSourceId);
-                  $el.find('.social-actions')
-                    .attr('data-global-datasource-id', globalDataSourceId);
-                  $el.find('.social-actions')
-                    .attr('data-entry-id', entryId);
-                });
-              } else if (selectedOption === 'Like') {
-                return connection.find({
-                  where,
-                  attributes: ['Email', 'Device Uuid']
-                }).then(function(records) {
-                  $el.find('.like').show();
-                  $el.find('.like-count').show();
-                  $el.find('.like-container').css('display', 'flex');
+          let currentSocialAction = $el.find('.social-actions');
 
-                  if (records && records.find(el =>
-                    el.data.Email === (user ? user.Email : '') || el.data['Device Uuid'] === deviceUuid)) {
-                    $el.find('.like')
-                      .addClass('fa-heart')
-                      .removeClass('fa-heart-o');
-                  }
-
-                  let currentSocialAction = $el.find('.social-actions');
-
-                  currentSocialAction
-                    .attr('data-original-datasource-id', dataSourceId)
-                    .attr('data-global-datasource-id', globalDataSourceId)
-                    .attr('data-entry-id', entryId);
-                  currentSocialAction.find('.like-count').html(records.length);
-                });
-              }
-            });
-        });
+          currentSocialAction
+            .attr('data-original-datasource-id', dataSourceId)
+            .attr('data-global-datasource-id', globalSocialActionsDSId)
+            .attr('data-entry-id', entryId);
+          currentSocialAction.find('.like-count').html(filteredGlobalSocialActionsDSData && filteredGlobalSocialActionsDSData.length);
+        }
       }
     },
     views: [


### PR DESCRIPTION
### Product areas affected
Fliplet Widget Social Actions

### What does this PR do?
Ensures Social actions are rendered with other elements at the same time.

### JIRA ticket
[DEV-161](https://weboo.atlassian.net/browse/DEV-161)

[DEV-161]: https://weboo.atlassian.net/browse/DEV-161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Eager initialise like/bookmark controls so states and counts appear immediately.
  * Consolidated wait-for-driven initialisation ensures attributes and data wiring are set once parents are ready.
  * Actions include recorded timestamps and available email/device identifiers.

* **Bug Fixes**
  * Reduced race conditions by awaiting data readiness before wiring UI interactions.
  * Shows a user-friendly “Still loading” notification if IDs are missing.
  * Prevents duplicate requests with a busy guard, normalises entry IDs, and surfaces friendly error toasts on failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->